### PR TITLE
update flush threshold for mongo opslog from 100k to 5k

### DIFF
--- a/target_s3/__init__.py
+++ b/target_s3/__init__.py
@@ -163,7 +163,7 @@ def main():
             i += 1
             stream_map, state = create_stream_to_record_map(stream_map, line, state, config)
 
-            if i == 100000:
+            if i == 5000:
                 flush(stream_map, tmp_path, config, s3)
                 i = 0
                 stream_map = {}


### PR DESCRIPTION
Currently spark jobs in AWS Glue have a hard time consuming large 250mb (100k line) files so I'd like to try 5k line files instead.